### PR TITLE
Fix bug in bootloader which causes it to reject binaries with version 0

### DIFF
--- a/bootloader/src/bootloader.c
+++ b/bootloader/src/bootloader.c
@@ -203,7 +203,7 @@ void handle_update(void)
         current_version = (uint32_t)OLDEST_VERSION;
     }
 
-    if (version < current_version) {
+    if ((version != 0) && (version < current_version)) {
         // Version is not acceptable
         uart_writeb(HOST_UART, FRAME_BAD);
         return;


### PR DESCRIPTION
As per section 3.3.3.1 of the rules, a "firmware image with version 0 which must be installable at any time." This commit, developed by @CMU-MITRE-Embedded-CTF allows the bootloader to install binaries with version 0.