### PR TITLE
Update gdb_flag_instructions.md

### DIFF
--- a/gdb_flag_instructions.md
+++ b/gdb_flag_instructions.md
@@ -13,7 +13,7 @@ instructions. Pull the image and create a new tag for it to be compatible with
 
 ```bash
 docker pull ectf/bootloader:gdb
-docker docker image tag ectf/bootloader:gdb gdb-challenge/bootloader
+docker image tag ectf/bootloader:gdb gdb-challenge/bootloader
 ```
 
 


### PR DESCRIPTION
Fix docker tag command to support copy paste.

Simple one line change to the GDB script to allow for easy copy paste of docker tagging command.