### PR TITLE
Fix the addresses for config storage

### DIFF
--- a/bootloader/src/bootloader.c
+++ b/bootloader/src/bootloader.c
@@ -34,8 +34,8 @@
  *      Msg:     0x0002B408 : 0x0002BC00 (~2KB = 1KB + 1B + pad)
  *      Fw:      0x0002BC00 : 0x0002FC00 (16KB)
  * Configuration:
- *      Size:    0x0002FC00 : 0x0003000 (1KB = 4B + pad)
- *      Cfg:     0x00030000 : 0x0004000 (64KB)
+ *      Size:    0x0002FC00 : 0x00030000 (1KB = 4B + pad)
+ *      Cfg:     0x00030000 : 0x00040000 (64KB)
  */
 #define FIRMWARE_METADATA_PTR      ((uint32_t)(FLASH_START + 0x0002B400))
 #define FIRMWARE_SIZE_PTR          ((uint32_t)(FIRMWARE_METADATA_PTR + 0))


### PR DESCRIPTION
This fixes the flash configuration addresses in the comments - https://github.com/mitre-cyber-academy/2022-ectf-insecure-example/blob/ff1197c2f2bf6904f4986d882afa57539969a609/bootloader/src/bootloader.c#L37-L38